### PR TITLE
Add CI jobs that run tests, lint, and format

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -34,13 +34,10 @@ jobs:
       - name: Run pre-commit hooks
         run: uvx pre-commit run --all-files
 
-      - name: Run mypy
-        run: uvx mypy src/ tests/ --ignore-missing-imports
-
       - name: Commit changes
         if: always()
         uses: EndBug/add-and-commit@v9
         with:
           default_author: github_actions
-          message: 'Apply pre-commit changes'
-          add: '*.py'
+          message: "Apply pre-commit changes"
+          add: "*.py"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,4 +27,4 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Test with pytest
-        run: uvx pytest tests --doctest-modules --junitxml=junit/test-results.xml
+        run: uv run pytest tests --doctest-modules --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,8 @@ jobs:
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Install the project
         run: uv sync --locked --all-extras --dev

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,3 +28,9 @@ jobs:
 
       - name: Test with pytest
         run: uv run pytest tests --doctest-modules --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ always() }}
+        with:
+          name: junit-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: junit/test-results.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,11 +20,9 @@ jobs:
 
       - name: "Set up Python"
         uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
 
       - name: Install the project
         run: uv sync --locked --all-extras --dev
 
       - name: Test with pytest
-        run: uvx pytest tests --doctest-modules --junitxml=junit/test-results.xml --cov=com --cov-report=xml --cov-report=html
+        run: uvx pytest tests --doctest-modules --junitxml=junit/test-results.xml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,7 +30,8 @@ jobs:
         run: uv run pytest tests --doctest-modules --junitxml=junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
 
       - uses: actions/upload-artifact@v4
+        name: Upload test results
         if: ${{ always() }}
         with:
           name: junit-${{ matrix.os }}-py${{ matrix.python-version }}
-          path: junit/test-results.xml
+          path: junit/test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dev = [
     "snakeviz>=2.2.2",
     "matplotlib>=3.10.3",
     "pyqt6>=6.9.1",
+    "junit2html>=31.0.2",
 ]
 
 [[tool.mypy.overrides]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,10 +70,15 @@ idna==3.10
     #   yarl
 iniconfig==2.1.0
     # via pytest
+jinja2==3.1.6
+    # via junit2html
+junit2html==31.0.2
 kiwisolver==1.4.8
     # via matplotlib
 lcm==1.5.1
     # via aspn23-lcm
+markupsafe==3.0.2
+    # via jinja2
 matplotlib==3.10.3
     # via
     #   pyvista

--- a/src/navtools/src/navtools/conversions/coordinates.py
+++ b/src/navtools/src/navtools/conversions/coordinates.py
@@ -115,14 +115,13 @@ class ENU(NamedTuple):
     up: float | np.ndarray
 
 
-# earth-centered earth-fixed (ECEF)
 def ecef2geodetic(
     x: float | np.ndarray,
     y: float | np.ndarray,
     z: float | np.ndarray,
     datum: GeodeticDatum = GeodeticDatum.from_datum(datum_name="wgs84"),
 ) -> GEODETIC:
-    """Borkowski closed-form cartesian to curvilinear conversion (Groves 2013).
+    """Olson's closed-form ECEF to geodetic conversion (IEEE Trans. 1996).
 
     Parameters
     ----------
@@ -154,27 +153,101 @@ def ecef2geodetic(
     >>> geod.lon.tolist()
     [0.0, 1.5707963267948966]
     """
-    k1 = np.sqrt(1 - datum.eccentricity**2) * np.abs(z)
-    k2 = datum.eccentricity**2 * datum.r0
-    beta = np.sqrt(x**2 + y**2)  # Eq. C.18
+    # Datum parameters
+    a = datum.r0
+    e2 = datum.eccentricity**2
 
-    E = (k1 - k2) / beta  # Eq. C.29
-    F = (k1 + k2) / beta  # Eq. C.30
+    # Precomputed constants for efficiency (as in original Olson C code)
+    a1 = a * e2
+    a2 = a1 * a1
+    a3 = a1 * e2 / 2
+    a4 = 2.5 * a2
+    a5 = a1 + a3
+    a6 = 1 - e2
 
-    P = 4 / 3 * (E * F + 1)  # Eq. C.31
-    Q = 2 * (E**2 - F**2)  # Eq. C.32
-    D = P**3 + Q**2  # Eq. C.33
-    V = (np.sqrt(D) - Q) ** (1 / 3) - (np.sqrt(D) + Q) ** (1 / 3)  # Eq. C.34
-    G = 0.5 * (np.sqrt(E**2 + V) + E)  # Eq. C.35
-    T = np.sqrt(G**2 + (F - V * G) / (2 * G - E)) - G  # Eq. C.36
+    # Basic coordinate calculations
+    zp = np.abs(z)
+    w2 = x**2 + y**2
+    w = np.sqrt(w2)
+    z2 = z**2
+    r2 = w2 + z2
+    r = np.sqrt(r2)
 
-    lat = np.sign(z) * np.arctan(
-        (1 - T**2) / (2 * T * np.sqrt(1 - datum.eccentricity**2))
-    )  # Eq. C.37
+    # Handle points too close to origin
+    near_origin = r < 100000.0
+
+    # Longitude calculation (valid everywhere except origin)
     lon = np.arctan2(y, x)
-    alt = (beta - datum.r0 * T) * np.cos(lat) + (
-        z - np.sign(z) * datum.r0 * np.sqrt(1 - datum.eccentricity**2)
-    ) * np.sin(lat)  # Eq. C.38
+
+    # Initialize latitude and altitude
+    lat = np.where(near_origin, 0.0, np.nan)
+    alt = np.where(near_origin, -1.0e7, np.nan)
+
+    # Process points far enough from origin
+    valid = ~near_origin
+    if np.any(valid):
+        # Extract valid coordinates for vectorized operations
+        r_v = np.where(valid, r, 1.0)  # Avoid division by zero
+        w2_v = np.where(valid, w2, 0.0)
+        z2_v = np.where(valid, z2, 0.0)
+        r2_v = np.where(valid, r2, 1.0)
+
+        # Normalized coordinates
+        s2 = z2_v / r2_v
+        c2 = w2_v / r2_v
+
+        # Olson's auxiliary variables
+        u = a2 / r_v
+        v = a3 - a4 / r_v
+
+        # Branch based on c2 value for numerical stability
+        high_c2 = valid & (c2 > 0.3)
+        low_c2 = valid & (c2 <= 0.3)
+
+        # High c2 branch: use sine formulation
+        if np.any(high_c2):
+            s = (zp / r) * (1.0 + c2 * (a1 + u + s2 * v) / r)
+            lat_temp = np.arcsin(s)
+            ss = s**2
+            c = np.sqrt(1.0 - ss)
+
+            lat = np.where(high_c2, lat_temp, lat)
+            s_out = np.where(high_c2, s, 0.0)
+            c_out = np.where(high_c2, c, 0.0)
+            ss_out = np.where(high_c2, ss, 0.0)
+        else:
+            s_out = np.zeros_like(r)
+            c_out = np.zeros_like(r)
+            ss_out = np.zeros_like(r)
+
+        # Low c2 branch: use cosine formulation
+        if np.any(low_c2):
+            c = (w / r) * (1.0 - s2 * (a5 - u - c2 * v) / r)
+            lat_temp = np.arccos(c)
+            ss = 1.0 - c**2
+            s = np.sqrt(ss)
+
+            lat = np.where(low_c2, lat_temp, lat)
+            s_out = np.where(low_c2, s, s_out)
+            c_out = np.where(low_c2, c, c_out)
+            ss_out = np.where(low_c2, ss, ss_out)
+
+        # final geodetic calculations
+        g = 1.0 - e2 * ss_out
+        rg = a / np.sqrt(g)
+        rf = a6 * rg
+        u_final = w - rg * c_out
+        v_final = zp - rf * s_out
+        f = c_out * u_final + s_out * v_final
+        m = c_out * v_final - s_out * u_final
+        p = m / (rf / g + f)
+
+        # Update latitude and calculate altitude
+        lat = np.where(valid, lat + p, lat)
+        alt = np.where(valid, f + m * p / 2.0, alt)
+
+    # Handle negative z coordinates
+    lat = np.where(z < 0.0, -lat, lat)
 
     return GEODETIC(lat=lat, lon=lon, alt=alt)
 

--- a/tests/test_coordinate_conversions.py
+++ b/tests/test_coordinate_conversions.py
@@ -1,11 +1,12 @@
-import navtools.conversions as ntc
 import numpy as np
-from navtools.constants import GEODETIC_DATUMS
 from pytest import approx
+
+import navtools.conversions as ntc
+from navtools.geodesy import GEODETIC_DATUMS
 
 
 def test_ecef_conversions():
-    WGS84 = GEODETIC_DATUMS["wgs84"]
+    WGS84 = GEODETIC_DATUMS["wgs84"]    
 
     lla = np.array(ntc.ecef2geodetic(x=WGS84.r0, y=0.0, z=0.0))
     assert lla == approx(np.zeros(3), rel=1e-9)

--- a/tests/test_coordinate_conversions.py
+++ b/tests/test_coordinate_conversions.py
@@ -1,12 +1,11 @@
-import numpy as np
-from pytest import approx
-
 import navtools.conversions as ntc
+import numpy as np
 from navtools.geodesy import GEODETIC_DATUMS
+from pytest import approx
 
 
 def test_ecef_conversions():
-    WGS84 = GEODETIC_DATUMS["wgs84"]    
+    WGS84 = GEODETIC_DATUMS["wgs84"]
 
     lla = np.array(ntc.ecef2geodetic(x=WGS84.r0, y=0.0, z=0.0))
     assert lla == approx(np.zeros(3), rel=1e-9)

--- a/tests/test_coordinate_conversions.py
+++ b/tests/test_coordinate_conversions.py
@@ -1,18 +1,452 @@
-import navtools.conversions as ntc
+from typing import Union
+
 import numpy as np
-from navtools.geodesy import GEODETIC_DATUMS
-from pytest import approx
+import pytest
+from numpy.testing import assert_allclose, assert_array_almost_equal
+
+# Assuming the module is imported as:
+from navtools.conversions.coordinates import (
+    ECEF,
+    ECI,
+    ENU,
+    GEODETIC,
+    C_ecef2enu,
+    C_enu2ecef,
+    ecef2enu,
+    ecef2geodetic,
+    enu2ecef,
+    enu2geodetic,
+    geodetic2ecef,
+    geodetic2enu,
+)
+from navtools.geodesy import GeodeticDatum
 
 
-def test_ecef_conversions():
-    WGS84 = GEODETIC_DATUMS["wgs84"]
+class TestCoordinateClasses:
+    """Test the coordinate system NamedTuple classes."""
 
-    lla = np.array(ntc.ecef2geodetic(x=WGS84.r0, y=0.0, z=0.0))
-    assert lla == approx(np.zeros(3), rel=1e-9)
+    def test_eci_creation(self):
+        """Test ECI coordinate creation and access."""
+        eci = ECI(x=7000e3, y=0, z=0)
+        assert eci.x == 7000000.0
+        assert eci.y == 0
+        assert eci.z == 0
 
-    ecef = np.array(ntc.geodetic2ecef(lat=90.0, lon=0.0, alt=0.0, deg=True))
-    assert ecef == approx(np.array([0.0, 0.0, WGS84.rp]), abs=1e-9)
+    def test_ecef_creation(self):
+        """Test ECEF coordinate creation and access."""
+        ecef = ECEF(x=6378137.0, y=0, z=0)
+        assert ecef.x == 6378137.0
+        assert ecef.y == 0
+        assert ecef.z == 0
+
+    def test_geodetic_creation(self):
+        """Test GEODETIC coordinate creation and access."""
+        geo = GEODETIC(lat=0.0, lon=0.0, alt=0.0)
+        assert geo.lat == 0.0
+        assert geo.lon == 0.0
+        assert geo.alt == 0.0
+
+    def test_enu_creation(self):
+        """Test ENU coordinate creation and access."""
+        enu = ENU(east=100.0, north=0.0, up=5.0)
+        assert enu.east == 100.0
+        assert enu.north == 0.0
+        assert enu.up == 5.0
+
+    def test_coordinate_with_arrays(self):
+        """Test coordinate classes with numpy arrays."""
+        x_arr = np.array([1.0, 2.0, 3.0])
+        y_arr = np.array([4.0, 5.0, 6.0])
+        z_arr = np.array([7.0, 8.0, 9.0])
+
+        ecef = ECEF(x=x_arr, y=y_arr, z=z_arr)
+        assert_array_almost_equal(ecef.x, x_arr)
+        assert_array_almost_equal(ecef.y, y_arr)
+        assert_array_almost_equal(ecef.z, z_arr)
+
+
+class TestGeodetic2ECEF:
+    """Test geodetic to ECEF conversions."""
+
+    def test_equator_prime_meridian(self):
+        """Test conversion at equator and prime meridian."""
+        ecef = geodetic2ecef(0.0, 0.0, 0.0)
+        assert_allclose(ecef.x, 6378137.0, rtol=1e-6)
+        assert_allclose(ecef.y, 0.0, atol=1e-9)
+        assert_allclose(ecef.z, 0.0, atol=1e-9)
+
+    def test_equator_90_degrees(self):
+        """Test conversion at equator and 90 degrees longitude."""
+        ecef = geodetic2ecef(0.0, np.pi / 2, 0.0)
+        assert_allclose(ecef.x, 0.0, atol=1e-9)
+        assert_allclose(ecef.y, 6378137.0, rtol=1e-6)
+        assert_allclose(ecef.z, 0.0, atol=1e-9)
+
+    def test_north_pole(self):
+        """Test conversion at north pole."""
+        ecef = geodetic2ecef(np.pi / 2, 0.0, 0.0)
+        assert_allclose(ecef.x, 0.0, atol=1e-9)
+        assert_allclose(ecef.y, 0.0, atol=1e-9)
+        assert_allclose(ecef.z, 6356752.314245179, rtol=1e-6)  # WGS84 polar radius
+
+    def test_with_altitude(self):
+        """Test conversion with non-zero altitude."""
+        alt = 1000.0  # 1km altitude
+        ecef = geodetic2ecef(0.0, 0.0, alt)
+        assert_allclose(ecef.x, 6378137.0 + alt, rtol=1e-6)
+        assert_allclose(ecef.y, 0.0, atol=1e-9)
+        assert_allclose(ecef.z, 0.0, atol=1e-9)
+
+    def test_degrees_input(self):
+        """Test conversion with degree inputs."""
+        ecef = geodetic2ecef(0.0, 90.0, 0.0, deg=True)
+        assert_allclose(ecef.x, 0.0, atol=1e-9)
+        assert_allclose(ecef.y, 6378137.0, rtol=1e-6)
+        assert_allclose(ecef.z, 0.0, atol=1e-9)
+
+    def test_array_input(self):
+        """Test conversion with array inputs."""
+        lats = np.array([0.0, np.pi / 2])
+        lons = np.array([0.0, 0.0])
+        alts = np.array([0.0, 0.0])
+
+        ecef = geodetic2ecef(lats, lons, alts)
+
+        # First point: equator, prime meridian
+        assert_allclose(ecef.x[0], 6378137.0, rtol=1e-6)
+        assert_allclose(ecef.y[0], 0.0, atol=1e-9)
+        assert_allclose(ecef.z[0], 0.0, atol=1e-9)
+
+        # Second point: north pole
+        assert_allclose(ecef.x[1], 0.0, atol=1e-9)
+        assert_allclose(ecef.y[1], 0.0, atol=1e-9)
+        assert_allclose(ecef.z[1], 6356752.314245179, rtol=1e-6)
+
+
+class TestECEF2Geodetic:
+    """Test ECEF to geodetic conversions."""
+
+    def test_equator_prime_meridian(self):
+        """Test conversion at equator and prime meridian."""
+        geo = ecef2geodetic(6378137.0, 0.0, 0.0)
+        assert_allclose(geo.lat, 0.0, atol=1e-9)
+        assert_allclose(geo.lon, 0.0, atol=1e-9)
+        assert_allclose(geo.alt, 0.0, atol=1e-3)
+
+    def test_equator_90_degrees(self):
+        """Test conversion at equator and 90 degrees longitude."""
+        geo = ecef2geodetic(0.0, 6378137.0, 0.0)
+        assert_allclose(geo.lat, 0.0, atol=1e-9)
+        assert_allclose(geo.lon, np.pi / 2, rtol=1e-6)
+        assert_allclose(geo.alt, 0.0, atol=1e-3)
+
+    def test_north_pole(self):
+        """Test conversion at north pole."""
+        geo = ecef2geodetic(0.0, 0.0, 6356752.314245179)
+        assert_allclose(geo.lat, np.pi / 2, rtol=1e-6)
+        # Longitude is undefined at poles, but should be finite
+        assert np.isfinite(geo.lon)
+        assert_allclose(geo.alt, 0.0, atol=1e-3)
+
+    def test_with_altitude(self):
+        """Test conversion with altitude."""
+        alt = 1000.0
+        geo = ecef2geodetic(6378137.0 + alt, 0.0, 0.0)
+        assert_allclose(geo.lat, 0.0, atol=1e-9)
+        assert_allclose(geo.lon, 0.0, atol=1e-9)
+        assert_allclose(geo.alt, alt, rtol=1e-6)
+
+    def test_array_input(self):
+        """Test conversion with array inputs."""
+        x = np.array([6378137.0, 0.0])
+        y = np.array([0.0, 6378137.0])
+        z = np.array([0.0, 0.0])
+
+        geo = ecef2geodetic(x, y, z)
+
+        # First point
+        assert_allclose(geo.lat[0], 0.0, atol=1e-9)
+        assert_allclose(geo.lon[0], 0.0, atol=1e-9)
+
+        # Second point
+        assert_allclose(geo.lat[1], 0.0, atol=1e-9)
+        assert_allclose(geo.lon[1], np.pi / 2, rtol=1e-6)
+
+
+class TestRoundTripConversions:
+    """Test round-trip conversions between coordinate systems."""
+
+    @pytest.mark.parametrize(
+        "lat,lon,alt",
+        [
+            (0.0, 0.0, 0.0),
+            (np.pi / 4, np.pi / 4, 1000.0),
+            (-np.pi / 6, -np.pi / 3, 5000.0),
+            (np.pi / 2 - 1e-6, 0.0, 0.0),  # Near north pole
+            (-np.pi / 2 + 1e-6, 0.0, 0.0),  # Near south pole
+        ],
+    )
+    def test_geodetic_ecef_roundtrip(self, lat, lon, alt):
+        """Test geodetic -> ECEF -> geodetic round trip."""
+        # Forward conversion
+        ecef = geodetic2ecef(lat, lon, alt)
+
+        # Reverse conversion
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+
+        # Check round-trip accuracy
+        assert_allclose(geo_back.lat, lat, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.lon, lon, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.alt, alt, rtol=1e-9, atol=1e-6)
+
+    def test_array_roundtrip(self):
+        """Test round-trip with array inputs."""
+        lats = np.array([0.0, np.pi / 4, -np.pi / 6])
+        lons = np.array([0.0, np.pi / 4, -np.pi / 3])
+        alts = np.array([0.0, 1000.0, 5000.0])
+
+        # Forward conversion
+        ecef = geodetic2ecef(lats, lons, alts)
+
+        # Reverse conversion
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+
+        # Check round-trip accuracy
+        assert_allclose(geo_back.lat, lats, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.lon, lons, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.alt, alts, rtol=1e-9, atol=1e-6)
+
+
+class TestECEF2ENU:
+    """Test ECEF to ENU conversions."""
+
+    def test_c_ecef2enu_basic(self):
+        """Test basic C_ecef2enu transformation."""
+        # At equator, prime meridian, ECEF x-axis points up in ENU
+        enu = C_ecef2enu(1.0, 0.0, 0.0, 0.0, 0.0)
+        assert_allclose(enu.east, 0.0, atol=1e-15)
+        assert_allclose(enu.north, 0.0, atol=1e-15)
+        assert_allclose(enu.up, 1.0, rtol=1e-15)
+
+    def test_c_ecef2enu_east_direction(self):
+        """Test east direction transformation."""
+        # At equator, prime meridian, ECEF y-axis points east in ENU
+        enu = C_ecef2enu(0.0, 1.0, 0.0, 0.0, 0.0)
+        assert_allclose(enu.east, 1.0, rtol=1e-15)
+        assert_allclose(enu.north, 0.0, atol=1e-15)
+        assert_allclose(enu.up, 0.0, atol=1e-15)
+
+    def test_c_ecef2enu_north_direction(self):
+        """Test north direction transformation."""
+        # At equator, prime meridian, ECEF z-axis points north in ENU
+        enu = C_ecef2enu(0.0, 0.0, 1.0, 0.0, 0.0)
+        assert_allclose(enu.east, 0.0, atol=1e-15)
+        assert_allclose(enu.north, 1.0, rtol=1e-15)
+        assert_allclose(enu.up, 0.0, atol=1e-15)
+
+    def test_ecef2enu_same_point(self):
+        """Test ECEF to ENU when points are the same."""
+        enu = ecef2enu(6378137.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert_allclose(enu.east, 0.0, atol=1e-6)
+        assert_allclose(enu.north, 0.0, atol=1e-6)
+        assert_allclose(enu.up, 0.0, atol=1e-6)
+
+    def test_ecef2enu_with_degrees(self):
+        """Test ECEF to ENU with degree inputs."""
+        enu = C_ecef2enu(1.0, 0.0, 0.0, 0.0, 0.0, deg=True)
+        assert_allclose(enu.up, 1.0, rtol=1e-15)
+
+
+class TestGeoetic2ENU:
+    """Test geodetic to ENU conversions."""
+
+    def test_geodetic2enu_same_point(self):
+        """Test geodetic to ENU when points are the same."""
+        enu = geodetic2enu(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert_allclose(enu.east, 0.0, atol=1e-9)
+        assert_allclose(enu.north, 0.0, atol=1e-9)
+        assert_allclose(enu.up, 0.0, atol=1e-9)
+
+    def test_geodetic2enu_altitude_difference(self):
+        """Test geodetic to ENU with altitude difference."""
+        enu = geodetic2enu(0.0, 0.0, 1000.0, 0.0, 0.0, 0.0)
+        assert_allclose(enu.east, 0.0, atol=1e-6)
+        assert_allclose(enu.north, 0.0, atol=1e-6)
+        assert_allclose(enu.up, 1000.0, rtol=1e-6)
+
+    def test_geodetic2enu_with_degrees(self):
+        """Test geodetic to ENU with degree inputs."""
+        enu = geodetic2enu(0.0, 0.0, 1000.0, 0.0, 0.0, 0.0, deg=True)
+        assert_allclose(enu.up, 1000.0, rtol=1e-6)
+
+
+class TestENU2ECEF:
+    """Test ENU to ECEF conversions."""
+
+    def test_c_enu2ecef_basic(self):
+        """Test basic C_enu2ecef transformation."""
+        # At equator, prime meridian, ENU up should give ECEF x
+        ecef = C_enu2ecef(0.0, 0.0, 1.0, 0.0, 0.0)
+        assert_allclose(ecef.x, 1.0, rtol=1e-15)
+        assert_allclose(ecef.y, 0.0, atol=1e-15)
+        assert_allclose(ecef.z, 0.0, atol=1e-15)
+
+    def test_c_enu2ecef_east_direction(self):
+        """Test east direction transformation."""
+        # At equator, prime meridian, ENU east should give ECEF y
+        ecef = C_enu2ecef(1.0, 0.0, 0.0, 0.0, 0.0)
+        assert_allclose(ecef.x, 0.0, atol=1e-15)
+        assert_allclose(ecef.y, 1.0, rtol=1e-15)
+        assert_allclose(ecef.z, 0.0, atol=1e-15)
+
+    def test_enu2ecef_zero_displacement(self):
+        """Test ENU to ECEF with zero displacement."""
+        ecef = enu2ecef(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        geo_origin = geodetic2ecef(0.0, 0.0, 0.0)
+        assert_allclose(ecef.x, geo_origin.x, rtol=1e-9)
+        assert_allclose(ecef.y, geo_origin.y, rtol=1e-9)
+        assert_allclose(ecef.z, geo_origin.z, rtol=1e-9)
+
+
+class TestENU2Geodetic:
+    """Test ENU to geodetic conversions."""
+
+    def test_enu2geodetic_zero_displacement(self):
+        """Test ENU to geodetic with zero displacement."""
+        geo = enu2geodetic(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        assert_allclose(geo.lat, 0.0, atol=1e-15)
+        assert_allclose(geo.lon, 0.0, atol=1e-15)
+        assert_allclose(geo.alt, 0.0, atol=1e-9)
+
+    def test_enu2geodetic_up_displacement(self):
+        """Test ENU to geodetic with upward displacement."""
+        geo = enu2geodetic(0.0, 0.0, 1000.0, 0.0, 0.0, 0.0)
+        assert_allclose(geo.lat, 0.0, atol=1e-9)
+        assert_allclose(geo.lon, 0.0, atol=1e-9)
+        assert_allclose(geo.alt, 1000.0, rtol=1e-6)
+
+
+class TestENU_Roundtrips:
+    """Test round-trip conversions involving ENU."""
+
+    def test_enu_ecef_roundtrip(self):
+        """Test ENU -> ECEF -> ENU round trip."""
+        east, north, up = 100.0, 200.0, 50.0
+        lat0, lon0, alt0 = np.pi / 6, np.pi / 4, 1000.0
+
+        # Forward conversion
+        ecef = enu2ecef(east, north, up, lat0, lon0, alt0)
+
+        # Reverse conversion
+        enu_back = ecef2enu(ecef.x, ecef.y, ecef.z, lat0, lon0, alt0)
+
+        # Check round-trip accuracy
+        assert_allclose(enu_back.east, east, rtol=1e-9)
+        assert_allclose(enu_back.north, north, rtol=1e-9)
+        assert_allclose(enu_back.up, up, rtol=1e-9)
+
+    def test_enu_geodetic_roundtrip(self):
+        """Test ENU -> geodetic -> ENU round trip."""
+        east, north, up = 100.0, 200.0, 50.0
+        lat0, lon0, alt0 = np.pi / 6, np.pi / 4, 1000.0
+
+        # Forward conversion
+        geo = enu2geodetic(east, north, up, lat0, lon0, alt0)
+
+        # Reverse conversion
+        enu_back = geodetic2enu(geo.lat, geo.lon, geo.alt, lat0, lon0, alt0)
+
+        # Check round-trip accuracy
+        assert_allclose(enu_back.east, east, rtol=1e-9, atol=1e-6)
+        assert_allclose(enu_back.north, north, rtol=1e-9, atol=1e-6)
+        assert_allclose(enu_back.up, up, rtol=1e-9, atol=1e-6)
+
+
+class TestEdgeCases:
+    """Test edge cases and error conditions."""
+
+    def test_near_poles(self):
+        """Test conversions near the poles."""
+        # Very close to north pole
+        lat_near_pole = np.pi / 2 - 1e-9
+        ecef = geodetic2ecef(lat_near_pole, 0.0, 0.0)
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+        assert_allclose(geo_back.lat, lat_near_pole, rtol=1e-9)
+
+    def test_negative_altitudes(self):
+        """Test with negative altitudes."""
+        alt = -1000.0  # Below ellipsoid
+        ecef = geodetic2ecef(0.0, 0.0, alt)
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+        assert_allclose(geo_back.alt, alt, rtol=1e-6)
+
+    def test_large_coordinates(self):
+        """Test with large coordinate values."""
+        # Test with coordinates at satellite altitudes
+        alt = 35786000.0  # Geostationary orbit altitude
+        ecef = geodetic2ecef(0.0, 0.0, alt)
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+        assert_allclose(geo_back.alt, alt, rtol=1e-6)
+
+    def test_zero_coordinates(self):
+        """Test with zero coordinates."""
+        geo = ecef2geodetic(0.0, 0.0, 0.0)
+        # Should handle gracefully without errors
+        assert np.isfinite(geo.lat)
+        assert np.isfinite(geo.lon)
+        assert np.isfinite(geo.alt)
+
+
+class TestArrayOperations:
+    """Test operations with various array shapes and sizes."""
+
+    def test_mixed_scalar_array(self):
+        """Test mixing scalar and array inputs."""
+        lats = np.array([0.0, np.pi / 4])
+        lon_scalar = 0.0
+        alt_scalar = 0.0
+
+        ecef = geodetic2ecef(lats, lon_scalar, alt_scalar)
+        assert len(ecef.x) == 2
+        assert len(ecef.y) == 2
+        assert len(ecef.z) == 2
+
+    def test_large_arrays(self):
+        """Test with larger arrays."""
+        n = 1000
+        lats = np.random.uniform(-np.pi / 2, np.pi / 2, n)
+        lons = np.random.uniform(-np.pi, np.pi, n)
+        alts = np.random.uniform(0, 10000, n)
+
+        ecef = geodetic2ecef(lats, lons, alts)
+        geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z)
+
+        # Check that all conversions are reasonable
+        assert_allclose(geo_back.lat, lats, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.lon, lons, rtol=1e-9, atol=1e-15)
+        assert_allclose(geo_back.alt, alts, rtol=1e-9, atol=1e-6)
+
+
+class TestCustomDatum:
+    """Test with custom geodetic datums."""
+
+    def test_custom_datum_roundtrip(self):
+        """Test round-trip with a custom datum."""
+        # This test assumes GeodeticDatum.from_datum works with other datums
+        # You may need to adjust based on your actual GeodeticDatum implementation
+        try:
+            custom_datum = GeodeticDatum.from_datum(datum_name="grs80")
+
+            lat, lon, alt = np.pi / 4, np.pi / 6, 1000.0
+            ecef = geodetic2ecef(lat, lon, alt, datum=custom_datum)
+            geo_back = ecef2geodetic(ecef.x, ecef.y, ecef.z, datum=custom_datum)
+
+            assert_allclose(geo_back.lat, lat, rtol=1e-9)
+            assert_allclose(geo_back.lon, lon, rtol=1e-9)
+            assert_allclose(geo_back.alt, alt, rtol=1e-9)
+        except:
+            pytest.skip("Custom datum not available")
 
 
 if __name__ == "__main__":
-    test_ecef_conversions()
+    pytest.main([__file__])

--- a/tests/test_coordinate_conversions.py
+++ b/tests/test_coordinate_conversions.py
@@ -2,7 +2,6 @@ from typing import Union
 
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose, assert_array_almost_equal
 
 # Assuming the module is imported as:
 from navtools.conversions.coordinates import (
@@ -20,6 +19,7 @@ from navtools.conversions.coordinates import (
     geodetic2enu,
 )
 from navtools.geodesy import GeodeticDatum
+from numpy.testing import assert_allclose, assert_array_almost_equal
 
 
 class TestCoordinateClasses:

--- a/uv.lock
+++ b/uv.lock
@@ -679,6 +679,29 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "junit2html"
+version = "31.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/78/e706ecbda2df0ea4b1c0479efbf74b12d061e09a9d537ea95c7b36bc8a2a/junit2html-31.0.2-py3-none-any.whl", hash = "sha256:c7fd1f253d423f0df031d0cee8ef7d4d98d9f8bf6383a2d40dca639686814866", size = 17513, upload-time = "2024-05-23T12:45:41.243Z" },
+]
+
+[[package]]
 name = "kiwisolver"
 version = "1.4.8"
 source = { registry = "https://pypi.org/simple" }
@@ -817,6 +840,64 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/61/09/f6329a505c10606bbbc7a3e327923e1c64a23e46db8bde959ef17161ce2c/lcm-1.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bbfd7a5fd5455d629a981d4454ae545184ec99cbe9cacefbcfb9950625cb72dd", size = 1507175, upload-time = "2024-12-23T19:12:40.121Z" },
     { url = "https://files.pythonhosted.org/packages/b6/67/4ea71f80c40f4efa6d75b684800b69fc1e7a49b1e754e369e0ac9c64833f/lcm-1.5.1-cp313-cp313-win32.whl", hash = "sha256:f2e8b958022127c259d9301fd2e1a8510ece5803c56c6d0bbd4e09d8aeda23f1", size = 4122665, upload-time = "2025-04-15T20:54:52.794Z" },
     { url = "https://files.pythonhosted.org/packages/fb/70/48989764b19174381874f166fd33e03baee61a58cc39df5f7658a63e49b8/lcm-1.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:b39b7a8b7b09b879b22c01f8d722de27b68ef00ed56e81de27f06171ad0cf5e9", size = 4341799, upload-time = "2025-04-15T20:54:54.74Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/90/d08277ce111dd22f77149fd1a5d4653eeb3b3eaacbdfcbae5afb2600eebd/MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8", size = 14357, upload-time = "2024-10-18T15:20:51.44Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e1/6e2194baeae0bca1fae6629dc0cbbb968d4d941469cbab11a3872edff374/MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158", size = 12393, upload-time = "2024-10-18T15:20:52.426Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/69/35fa85a8ece0a437493dc61ce0bb6d459dcba482c34197e3efc829aa357f/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38a9ef736c01fccdd6600705b09dc574584b89bea478200c5fbf112a6b0d5579", size = 21732, upload-time = "2024-10-18T15:20:53.578Z" },
+    { url = "https://files.pythonhosted.org/packages/22/35/137da042dfb4720b638d2937c38a9c2df83fe32d20e8c8f3185dbfef05f7/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bbcb445fa71794da8f178f0f6d66789a28d7319071af7a496d4d507ed566270d", size = 20866, upload-time = "2024-10-18T15:20:55.06Z" },
+    { url = "https://files.pythonhosted.org/packages/29/28/6d029a903727a1b62edb51863232152fd335d602def598dade38996887f0/MarkupSafe-3.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:57cb5a3cf367aeb1d316576250f65edec5bb3be939e9247ae594b4bcbc317dfb", size = 20964, upload-time = "2024-10-18T15:20:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cd/07438f95f83e8bc028279909d9c9bd39e24149b0d60053a97b2bc4f8aa51/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3809ede931876f5b2ec92eef964286840ed3540dadf803dd570c3b7e13141a3b", size = 21977, upload-time = "2024-10-18T15:20:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/29/01/84b57395b4cc062f9c4c55ce0df7d3108ca32397299d9df00fedd9117d3d/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e07c3764494e3776c602c1e78e298937c3315ccc9043ead7e685b7f2b8d47b3c", size = 21366, upload-time = "2024-10-18T15:20:58.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/6e/61ebf08d8940553afff20d1fb1ba7294b6f8d279df9fd0c0db911b4bbcfd/MarkupSafe-3.0.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b424c77b206d63d500bcb69fa55ed8d0e6a3774056bdc4839fc9298a7edca171", size = 21091, upload-time = "2024-10-18T15:20:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/11/23/ffbf53694e8c94ebd1e7e491de185124277964344733c45481f32ede2499/MarkupSafe-3.0.2-cp310-cp310-win32.whl", hash = "sha256:fcabf5ff6eea076f859677f5f0b6b5c1a51e70a376b0579e0eadef8db48c6b50", size = 15065, upload-time = "2024-10-18T15:21:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/44/06/e7175d06dd6e9172d4a69a72592cb3f7a996a9c396eee29082826449bbc3/MarkupSafe-3.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:6af100e168aa82a50e186c82875a5893c5597a0c1ccdb0d8b40240b1f28b969a", size = 15514, upload-time = "2024-10-18T15:21:01.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload-time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload-time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload-time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload-time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload-time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload-time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload-time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload-time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload-time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload-time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
@@ -1098,6 +1179,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "junit2html" },
     { name = "matplotlib" },
     { name = "mypy" },
     { name = "pre-commit" },
@@ -1117,6 +1199,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "junit2html", specifier = ">=31.0.2" },
     { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "mypy", specifier = ">=1.11.1" },
     { name = "pre-commit", specifier = ">=3.8.0" },


### PR DESCRIPTION
This removes mypy type testing right now. It will hopefully be added later. Additionally, I added coordinate conversion tests and subsequently improved the `ecef2geodetic` function to handle the poles better.