### PR TITLE
Add user-defined noise and static trajectory ability

### DIFF
--- a/src/navsim/SIMULATION.md
+++ b/src/navsim/SIMULATION.md
@@ -1,4 +1,4 @@
-# navsim Built-In Simulation Guide
+# navsim Simulation Guide
 
 This guide explains how to configure navigation simulations using the navsim configuration system. navsim uses TOML files to define simulation parameters, making it easy to create reproducible and shareable simulation scenarios.
 
@@ -37,39 +37,43 @@ navsim configuration files use TOML format and are organized into several sectio
 The general section defines the fundamental simulation parameters:
 
 ### `initial_datetime`
+
 - **Type**: ISO 8601 datetime string
 - **Description**: Simulation start time
 - **Format**: `YYYY-MM-DDTHH:MM:SS+TZ:TZ` or `YYYY-MM-DDTHH:MM:SS-TZ:TZ`
 - **Example**: `2024-06-14T00:00:00-00:00`
 
 ### `duration`
+
 - **Type**: Float
 - **Units**: Seconds
 - **Description**: Total simulation duration
 - **Example**: `7200` (2 hours)
 
 ### `fsim`
+
 - **Type**: Float
 - **Units**: Hz
 - **Description**: Simulation step frequency (temporal resolution)
 - **Example**: `1` (1 Hz = 1-second steps)
-- **Common Values**: 
+- **Common Values**:
   - `1.0` - Standard resolution
   - `10.0` - High resolution
   - `0.1` - Low resolution for long simulations
 
 ### `trajectory_name`
+
 - **Type**: String
 - **Description**: Identifier for the trajectory to simulate
 - **Example**: `"road_finland_sdx_01_onego"`
 - **Notes**: Must correspond to an available trajectory in your simulation system
 
-
 ## Measurement Configuration
 
 ### Error Modeling Parameters
 
-#### `rx_clock_type`
+### `rx_clock_type`
+
 - **Type**: String
 - **Description**: Receiver clock model type
 - **Options**:
@@ -80,40 +84,67 @@ The general section defines the fundamental simulation parameters:
   - `"cesium"` - Cesium Atomic Clock
 - **Example**: `"ocxo"`
 
-#### `rx_noise`
+### `rx_noise`
+
 - **Type**: Boolean
 - **Description**: Enable realistic thermal noise modeling
 - **Example**: `true`
 
-#### `ionosphere`
+### `ionosphere`
+
 - **Type**: Boolean
 - **Description**: Enable ionospheric delay modeling
 - **Example**: `true`
 - **Notes**: Models signal delays caused by charged particles in the ionosphere
 
-#### `troposphere`
+### `troposphere`
+
 - **Type**: Boolean
 - **Description**: Enable tropospheric delay modeling
 - **Example**: `false`
 - **Notes**: Models signal delays caused by water vapor and atmospheric pressure
+
+### `pseudorange_awgn_sigma`
+
+- **Type**: Float
+- **Description**: Optional 1-$\sigma$ value (in meters) for generating user-defined additive white Gaussian pseudorange noise
+- **Example**: `5.0`
+- **Notes**: Can replace or supplement `rx_noise`, which is based on carrier-to-noise density ratio
+
+### `doppler_awgn_sigma`
+
+- **Type**: Float
+- **Description**: Optional 1-$\sigma$ value (in Hz) for generating user-defined additive white Gaussian Doppler noise
+- **Example**: `2.0`
+- **Notes**: Can replace or supplement `rx_noise`, which is based on carrier-to-noise density ratio
+
+### `carrier_phase_awgn_sigma`
+
+- **Type**: Float
+- **Description**: Optional 1-$\sigma$ value (in cycles) for generating user-defined additive white Gaussian carrier phase noise
+- **Example**: `0.2`
+- **Notes**: Can replace or supplement `rx_noise`, which is based on carrier-to-noise density ratio
 
 ## Constellation Configuration
 
 Constellations are defined as arrays using the `[[constellation]]` TOML array syntax. You can define multiple constellations in a single simulation.
 
 ### `reference_constellation`
+
 - **Type**: String
 - **Description**: Name of the satellite constellation
 - **Options**: [Supported Constellations](./CONSTELLATIONS.md)
 - **Example**: `"gps"`
 
 ### `signals`
+
 - **Type**: Array of strings
 - **Description**: List of signal types to simulate
 - **Options**: [Satellite Signals Reference](./SIGNALS.md)
 - **Examples**: `["GPS_L1C"]`, `["GPS_L1C", "GALILEO_L1B"]`
 
 ### `mask_angle`
+
 - **Type**: Float
 - **Units**: Degrees
 - **Description**: Elevation mask angle below which satellites are ignored
@@ -121,6 +152,7 @@ Constellations are defined as arrays using the `[[constellation]]` TOML array sy
 - **Notes**: Satellites below this angle are not used
 
 ### `transmit_eirp`
+
 - **Type**: Float
 - **Units**: dBW (decibels relative to one watt)
 - **Description**: Effective Isotropic Radiated Power of satellite signals at transmission
@@ -129,6 +161,7 @@ Constellations are defined as arrays using the `[[constellation]]` TOML array sy
 - **Example**: `29.5`
 
 ### `cn0_attenuation`
+
 - **Type**: Float
 - **Units**: dB
 - **Description**: Additional attenuation applied to carrier-to-noise ratio
@@ -151,6 +184,9 @@ rx_clock_type = "ocxo"
 rx_noise = true
 ionosphere = true
 troposphere = false
+pseudorange_awgn_sigma = 5.0   # [m]
+doppler_awgn_sigma = 2.0       # [Hz]
+carrier_phase_awgn_sigma = 0.2 # [cycles]
 
 # GPS constellation
 [[constellation]]
@@ -174,23 +210,30 @@ cn0_attenuation = 15   # [dB]
 ### Common Configuration Errors
 
 #### Missing Required Fields
+
 ```
 ValueError: Missing required fields: {'initial_datetime', 'duration'}
 ```
+
 **Solution**: Ensure all required fields are present in your TOML file.
 
 #### Invalid TOML Syntax
+
 ```
 tomli.TOMLDecodeError: Invalid value type at line X
 ```
+
 **Solution**: Check TOML syntax, especially:
+
 - String values must be quoted: `"value"`
 - Arrays use square brackets: `["item1", "item2"]`
 - Datetime format: `"YYYY-MM-DDTHH:MM:SS±TZ:TZ"`
 
 #### Timezone Issues
+
 The system automatically converts datetime to UTC, but ensure your initial datetime includes timezone information:
+
 - **Correct**: `"2024-06-14T00:00:00+00:00"`
 - **Incorrect**: `"2024-06-14T00:00:00"` (no timezone)
 
-This guide should help you create and configure navsim simulations effectively. For more advanced configuration options or specific constellation parameters, refer to the navsim documentation.
+This guide should help you create and configure navsim simulations effectively.

--- a/src/navsim/src/navsim/config/example_beidou.toml
+++ b/src/navsim/src/navsim/config/example_beidou.toml
@@ -3,7 +3,6 @@ initial_datetime = 2024-06-14T00:00:00-00:00
 duration = 7200                              # [s]
 fsim = 1                                     # [Hz]
 trajectory_name = "road_japan_sdx_01s_onego"
-output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"

--- a/src/navsim/src/navsim/config/example_beidou.toml
+++ b/src/navsim/src/navsim/config/example_beidou.toml
@@ -1,9 +1,9 @@
 # General
-initial_datetime=2024-06-14T00:00:00-00:00
-duration=7200 # [s]
-fsim=1 # [Hz]
-trajectory_name="road_japan_sdx_01s_onego"
-output_log_path=true
+initial_datetime = 2024-06-14T00:00:00-00:00
+duration = 7200                              # [s]
+fsim = 1                                     # [Hz]
+trajectory_name = "road_japan_sdx_01s_onego"
+output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"
@@ -13,8 +13,8 @@ troposphere = false
 
 
 [[constellation]]
-reference_constellation="beidou"
-signals=["beidou_l1d"]
-mask_angle=10 # [deg]
-transmit_eirp=29.5 # [dBW]
-cn0_attenuation=20 # [dB]
+reference_constellation = "beidou"
+signals = ["beidou_l1d"]
+mask_angle = 10                    # [deg]
+transmit_eirp = 29.5               # [dBW]
+cn0_attenuation = 20               # [dB]

--- a/src/navsim/src/navsim/config/example_galileo-iridium.toml
+++ b/src/navsim/src/navsim/config/example_galileo-iridium.toml
@@ -3,7 +3,6 @@ initial_datetime = 2024-06-14T00:00:00-00:00
 duration = 7200                              # [s]
 fsim = 1                                     # [Hz]
 trajectory_name = "road_japan_sdx_01s_onego"
-output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"

--- a/src/navsim/src/navsim/config/example_galileo-iridium.toml
+++ b/src/navsim/src/navsim/config/example_galileo-iridium.toml
@@ -1,9 +1,9 @@
 # General
-initial_datetime=2024-06-14T00:00:00-00:00
-duration=7200 # [s]
-fsim=1 # [Hz]
-trajectory_name="road_japan_sdx_01s_onego"
-output_log_path=true
+initial_datetime = 2024-06-14T00:00:00-00:00
+duration = 7200                              # [s]
+fsim = 1                                     # [Hz]
+trajectory_name = "road_japan_sdx_01s_onego"
+output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"
@@ -13,15 +13,15 @@ troposphere = false
 
 
 [[constellation]]
-reference_constellation="galileo"
-signals=["galileo_l1b"]
-mask_angle=10 # [deg]
-transmit_eirp=29.5 # [dBW]
-cn0_attenuation=20 # [dB]
+reference_constellation = "galileo"
+signals = ["galileo_l1b"]
+mask_angle = 10                     # [deg]
+transmit_eirp = 29.5                # [dBW]
+cn0_attenuation = 20                # [dB]
 
 [[constellation]]
-reference_constellation="iridium"
-signals=["iridium_l"]
-mask_angle=30 # [deg]
-transmit_eirp=45.0 # [dBW]
-cn0_attenuation=20 # [dB]
+reference_constellation = "iridium"
+signals = ["iridium_l"]
+mask_angle = 30                     # [deg]
+transmit_eirp = 45.0                # [dBW]
+cn0_attenuation = 20                # [dB]

--- a/src/navsim/src/navsim/config/example_gps-globalstar.toml
+++ b/src/navsim/src/navsim/config/example_gps-globalstar.toml
@@ -3,7 +3,6 @@ initial_datetime = 2024-06-14T00:00:00-00:00
 duration = 7200                              # [s]
 fsim = 1                                     # [Hz]
 trajectory_name = "road_japan_sdx_01s_onego"
-output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"

--- a/src/navsim/src/navsim/config/example_gps.toml
+++ b/src/navsim/src/navsim/config/example_gps.toml
@@ -3,7 +3,7 @@ initial_datetime = 2024-06-14T00:00:00-00:00
 duration = 7200                               # [s]
 fsim = 1                                      # [Hz]
 trajectory_name = "road_finland_sdx_01_onego"
-output_log_path = true
+is_static = true
 
 # Errors
 rx_clock_type = "ocxo"

--- a/src/navsim/src/navsim/config/example_gps.toml
+++ b/src/navsim/src/navsim/config/example_gps.toml
@@ -1,21 +1,22 @@
 # General
-initial_datetime=2024-06-14T00:00:00-00:00
-duration=7200 # [s]
-fsim=1 # [Hz]
-trajectory_name="road_finland_sdx_01_onego"
-output_log_path=true
+initial_datetime = 2024-06-14T00:00:00-00:00
+duration = 7200                               # [s]
+fsim = 1                                      # [Hz]
+trajectory_name = "road_finland_sdx_01_onego"
+output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"
 rx_noise = true
 ionosphere = true
 troposphere = false
-
+pseudorange_awgn_sigma = 5.0   # [m]
+doppler_awgn_sigma = 2.0       # [Hz]
+carrier_phase_awgn_sigma = 0.2 # [cycles]
 
 [[constellation]]
-reference_constellation="gps"
-signals=["gps_l1c"]
-mask_angle=10 # [deg]
-transmit_eirp=29.5 # [dBW]
-cn0_attenuation=20 # [dB]
-
+reference_constellation = "gps"
+signals = ["gps_l1c"]
+mask_angle = 10                 # [deg]
+transmit_eirp = 29.5            # [dBW]
+cn0_attenuation = 20            # [dB]

--- a/src/navsim/src/navsim/config/example_starlink.toml
+++ b/src/navsim/src/navsim/config/example_starlink.toml
@@ -1,9 +1,9 @@
 # General
-initial_datetime=2024-06-14T00:00:00-00:00
-duration=7200 # [s]
-fsim=1 # [Hz]
-trajectory_name="flight_usa_sdx_01s_onego"
-output_log_path=true
+initial_datetime = 2024-06-14T00:00:00-00:00
+duration = 7200                              # [s]
+fsim = 1                                     # [Hz]
+trajectory_name = "flight_usa_sdx_01s_onego"
+output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"
@@ -13,9 +13,8 @@ troposphere = false
 
 
 [[constellation]]
-reference_constellation="starlink"
-signals=["starlink_ku"]
-mask_angle=30 # [deg]
-transmit_eirp=29.5 # [dBW]
-cn0_attenuation=20 # [dB]
-
+reference_constellation = "starlink"
+signals = ["starlink_ku"]
+mask_angle = 30                      # [deg]
+transmit_eirp = 29.5                 # [dBW]
+cn0_attenuation = 20                 # [dB]

--- a/src/navsim/src/navsim/config/example_starlink.toml
+++ b/src/navsim/src/navsim/config/example_starlink.toml
@@ -3,7 +3,6 @@ initial_datetime = 2024-06-14T00:00:00-00:00
 duration = 7200                              # [s]
 fsim = 1                                     # [Hz]
 trajectory_name = "flight_usa_sdx_01s_onego"
-output_log_path = true
 
 # Errors
 rx_clock_type = "ocxo"

--- a/src/navsim/src/navsim/simulations/configuration.py
+++ b/src/navsim/src/navsim/simulations/configuration.py
@@ -8,9 +8,9 @@ except ImportError:
     import tomli as tl
 
 from typing import Any, Dict, Type, TypeVar
+from zoneinfo import ZoneInfo
 
 from navtools.io import select_file
-from zoneinfo import ZoneInfo
 
 
 @dataclass
@@ -81,6 +81,12 @@ class MeasurementConfiguration:
     troposphere : bool
         Whether to model tropospheric delay effects in the simulation.
         If True, tropospheric corrections will be applied to measurements.
+    pseudorange_awgn_sigma : float
+        Adds user-defined additive white Gaussian noise to pseduoranges using 1-σ value in meters.
+    doppler_awgn_sigma : float
+        Adds user-defined additive white Gaussian noise to Doppler using 1-σ value in Hz.
+    carrier_phase_awgn_sigma : float
+        Adds user-defined additive white Gaussian noise to carrier phase using 1-σ value in cycles.
 
     Examples
     --------
@@ -99,6 +105,9 @@ class MeasurementConfiguration:
     rx_noise: bool
     ionosphere: bool
     troposphere: bool
+    pseudorange_awgn_sigma: float = 0.0  # [m]
+    doppler_awgn_sigma: float = 0.0  # [Hz]
+    carrier_phase_awgn_sigma: float = 0.0  # [cycles]
 
 
 @dataclass

--- a/src/navsim/src/navsim/simulations/configuration.py
+++ b/src/navsim/src/navsim/simulations/configuration.py
@@ -8,9 +8,9 @@ except ImportError:
     import tomli as tl
 
 from typing import Any, Dict, Type, TypeVar
-from zoneinfo import ZoneInfo
 
 from navtools.io import select_file
+from zoneinfo import ZoneInfo
 
 
 @dataclass

--- a/src/navsim/src/navsim/simulations/configuration.py
+++ b/src/navsim/src/navsim/simulations/configuration.py
@@ -82,11 +82,11 @@ class MeasurementConfiguration:
         Whether to model tropospheric delay effects in the simulation.
         If True, tropospheric corrections will be applied to measurements.
     pseudorange_awgn_sigma : float
-        Adds user-defined additive white Gaussian noise to pseduoranges using 1-σ value in meters.
+        Adds user-defined additive white Gaussian noise to pseduoranges using 1-σ value in meters. Default value is 0.0.
     doppler_awgn_sigma : float
-        Adds user-defined additive white Gaussian noise to Doppler using 1-σ value in Hz.
+        Adds user-defined additive white Gaussian noise to Doppler using 1-σ value in Hz. Default value is 0.0.
     carrier_phase_awgn_sigma : float
-        Adds user-defined additive white Gaussian noise to carrier phase using 1-σ value in cycles.
+        Adds user-defined additive white Gaussian noise to carrier phase using 1-σ value in cycles. Default value is 0.0.
 
     Examples
     --------
@@ -132,6 +132,8 @@ class GeneralConfiguration:
     trajectory_name : str
         Name identifier of the trajectory to simulate. This should correspond
         to a trajectory definition available in the navsim `trajectories` folder.
+    is_static : bool
+        Determines whether the entire duration is static at the first point in the selected trajectory. Default value is False.
 
     Examples
     --------
@@ -148,6 +150,7 @@ class GeneralConfiguration:
     duration: float
     fsim: float
     trajectory_name: str
+    is_static: bool = False
 
 
 @dataclass

--- a/src/navsim/src/navsim/simulations/measurement.py
+++ b/src/navsim/src/navsim/simulations/measurement.py
@@ -297,6 +297,9 @@ class MeasurementSimulation:
                     ) = self._compute_rx_noise(cn0=cn0, fcarrier=signal.fcarrier)
 
                     # compute pseudorange
+                    user_prange_noise = self._prange_awgn_sigma * np.random.randn(
+                        timestamps.size
+                    )
                     prange = (
                         los_range
                         + iono_delays
@@ -304,6 +307,7 @@ class MeasurementSimulation:
                         + rx_cb
                         - emitter_cb
                         + dll_noise
+                        + user_prange_noise
                     )
 
                     # compute doppler
@@ -311,14 +315,24 @@ class MeasurementSimulation:
                         los_range_rate - iono_drifts + tropo_drifts + rx_cd - emitter_cd
                     )
                     prange_rate = noiseless_prange_rate + fll_noise
-                    doppler = -prange_rate * signal.fcarrier / SPEED_OF_LIGHT
+                    user_doppler_noise = self._doppler_awgn_sigma * np.random.randn(
+                        timestamps.size
+                    )
+                    doppler = (
+                        -prange_rate * signal.fcarrier / SPEED_OF_LIGHT
+                    ) + user_doppler_noise
 
                     # compute carrier phase
+                    user_phase_noise = self._carrier_phase_awgn_sigma * np.random.randn(
+                        timestamps.size
+                    )
                     # #TODO: figure out timing and correct calculation
                     noiseless_doppler = (
                         -noiseless_prange_rate * signal.fcarrier / SPEED_OF_LIGHT
                     )
-                    carrier_phase = np.cumsum(noiseless_doppler) + pll_noise
+                    carrier_phase = (
+                        np.cumsum(noiseless_doppler) + pll_noise + user_phase_noise
+                    )
                     lock_count = np.arange(0, carrier_phase.size).tolist()
 
                     # package observable data in aspn type
@@ -458,6 +472,9 @@ class MeasurementSimulation:
         self._troposphere = config.troposphere
         self._rx_noise = config.rx_noise
         self._rx_clock = NAVIGATION_CLOCKS[config.rx_clock_type.casefold()]
+        self._prange_awgn_sigma = config.pseudorange_awgn_sigma
+        self._doppler_awgn_sigma = config.doppler_awgn_sigma
+        self._carrier_phase_awgn_sigma = config.carrier_phase_awgn_sigma
 
         # assing constellation specific
         self._mask_angles = {}

--- a/src/navsim/src/navsim/simulations/simulation.py
+++ b/src/navsim/src/navsim/simulations/simulation.py
@@ -73,6 +73,7 @@ def simulate(config_dir: Optional[pl.Path] = None, log_dir: Optional[pl.Path] = 
     rx_pos, rx_vel = create_trajectory(
         trajectory_name=config.general.trajectory_name,
         sim_timeseries=sim_timeseries,
+        is_static=config.general.is_static,
     )
 
     # create simulation and begin
@@ -159,8 +160,7 @@ def generate_timeseries(
 
 
 def create_trajectory(
-    trajectory_name: str,
-    sim_timeseries: ArrayLike,
+    trajectory_name: str, sim_timeseries: ArrayLike, is_static: bool
 ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
     """
     Load and interpolate a predefined trajectory to simulation times.
@@ -171,6 +171,8 @@ def create_trajectory(
         Name of the sample trajectory to load.
     sim_timeseries : array-like of float
         Elapsed simulation times at which to interpolate.
+    is_static : bool
+        Determines whether the entire duration is static at the first point in the selected trajectory.
 
     Returns
     -------
@@ -187,6 +189,11 @@ def create_trajectory(
     traj_timeseries, traj_lat, traj_lon, traj_alt = load_sample_trajectory(
         trajectory_name=trajectory_name
     )
+
+    if is_static:
+        traj_lat = np.repeat(traj_lat[0], traj_timeseries.size)
+        traj_lon = np.repeat(traj_lon[0], traj_timeseries.size)
+        traj_alt = np.repeat(traj_alt[0], traj_timeseries.size)
 
     rx_pos_ecef, rx_vel_ecef = interpolate_trajectory(
         time=traj_timeseries,


### PR DESCRIPTION
Allows for the user to add their own noise to each measurement with a 1-$\sigma$ value in meters, Hz, or cycles for each respective measurement. Additionally, the user can nowselect whether they want to have the receiver position be static at the start of the selected trajectory.